### PR TITLE
Set up Docker environment with Compose for tournament application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:24-jdk-slim
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,1 +1,22 @@
-#services:
+services:
+    db:
+        image: postgres:15
+        restart: always
+        environment:
+            POSTGRES_USER: postgres
+            POSTGRES_PASSWORD: KeyinSD12
+            POSTGRES_DB: tournamentdb
+
+
+
+    tournament:
+        build: .
+        image: com.teeparty.tournament:latest
+        depends_on:
+            - db
+        ports:
+          - "8080:8080"
+        environment:
+          SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/tournamentdb  # PostgreSQL connection URL
+          SPRING_DATASOURCE_USERNAME: postgres  # Username for PostgreSQL
+          SPRING_DATASOURCE_PASSWORD: KeyinSD12  # Password for PostgreSQL


### PR DESCRIPTION
Add `compose.yaml` to define services for PostgreSQL and the tournament application. Include `Dockerfile` for building the application image.